### PR TITLE
[KP-1392] make action-level host or port override account level config

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,8 +4,8 @@ const helpers = require("./helpers");
 async function execCommand(action) {
   const { username } = action.params;
   const { password } = action.params;
-  const port = action.params.port || 5985;
-  const { host } = action.params;
+  const port = action.params.actionPort || action.params.port || 5985;
+  const host = action.params.actionHost || action.params.host || "127.0.0.1";
 
   const encodedCredentials = Buffer.from(`${username}:${password}`, "utf8").toString("base64");
   const params = {

--- a/config.json
+++ b/config.json
@@ -60,7 +60,7 @@
       "viewName": "Execute remote command",
       "params": [
         {
-          "name": "host",
+          "name": "actionHost",
           "viewName": "Hostname",
           "description": "Hostname or IP address of Windows server",
           "type": "string",
@@ -68,7 +68,7 @@
           "placeholder": "12.13.14.15"
         },
         {
-          "name": "port",
+          "name": "actionPort",
           "viewName": "Port",
           "description": "Port, if other than standard 5985 is used",
           "type": "string",


### PR DESCRIPTION
Had to use a different parameter name at action level because on platform side plugin account always takes precedence.